### PR TITLE
Feat/add object acl param and template for s3 bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,24 @@ options with `accessKeyName` and `secretAccessKeyName`.
 | `removeDirectoryRoot`    | Flag that determines will the root directory of the given `directoryPath` be removed                    |  false  |          |
 | `removeDiff`             | Flag that determines will the file diff which should be uploaded vs files already on s3 will be deleted |  true   |          |
 
+
+#### `s3Bucket option`
+
+The s3Bucket name can contain variable, is is parsed with [Lodash template](https://lodash.com/docs#template). The following variables are available:
+
+| Parameter      | Description                                                                          |
+| -------------- | ------------------------------------------------------------------------------------ |
+| `branch.name`  | The branch name.                                                                     |
+| `lastRelease`  | `Object` with `version`, `gitTag` and `gitHead` of the last release.                 |
+| `nextRelease`  | `Object` with `version`, `gitTag`, `gitHead` and `notes` of the release being done.  |
+
+##### `s3Bucket` examples
+
+The `s3Bucket` `my-bucket/${nextRelease.version}` will generate push your object to this path:
+
+> my-bucket/v1.0.0/[your-directory-content]
+
+
 ### Example
 
 ```json

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ options with `accessKeyName` and `secretAccessKeyName`.
 | `awsAccessKeyName`       | Environmental variable name that is used to override `AWS_ACCESS_KEY_ID`                                |         |          |
 | `awsSecretAccessKeyName` | Environmental variable name that is used to override `AWS_SECRET_ACCESS_KEY`                            |         |          |
 | `s3Bucket`               | S3 bucket configuration can be defined per git branch or a single bucket                                |         |    ✓     |
+| `objectACL`              | S3 object ACL ("private"|"public-read"|"public-read-write"|"authenticated-read"...)                     |         |          |
 | `directoryPath`          | Path to directory which will be uploaded to the bucket                                                  |         |    ✓     |
 | `removeDirectoryRoot`    | Flag that determines will the root directory of the given `directoryPath` be removed                    |  false  |          |
 | `removeDiff`             | Flag that determines will the file diff which should be uploaded vs files already on s3 will be deleted |  true   |          |
@@ -80,6 +81,7 @@ options with `accessKeyName` and `secretAccessKeyName`.
                 "awsAccessKeyName": "ACCESS_KEY_ENV_VARIABLE_NAME",
                 "awsSecretAccessKeyName": "SECRET_ACCESS_KEY_ENV_VARIABLE_NAME",
                 "s3Bucket": "s3-bucket-name",
+                "objectACL": "public-read",
                 "directoryPath": "directoryName/**/*",
                 "removeDirectoryRoot": true,
                 "removeDiff": false

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
         "aggregate-error": "^3.1.0",
         "aws-sdk": "^2.1325.0",
         "globby": "^11.1.0",
+        "lodash.template": "^4.5.0",
         "mime-types": "^2.1.35"
     },
     "devDependencies": {
@@ -60,6 +61,7 @@
         "@semantic-release/github": "^8.0.7",
         "@semantic-release/npm": "^9.0.2",
         "@semantic-release/release-notes-generator": "^10.0.3",
+        "@types/lodash.template": "^4.5.1",
         "@types/mime-types": "^2.1.1",
         "@types/semantic-release": "^20.0.1",
         "commitizen": "^4.3.0",

--- a/src/aws.ts
+++ b/src/aws.ts
@@ -9,6 +9,7 @@ import {
 import type {
     ListObjectsV2Request,
     ManagedUpload,
+    ObjectCannedACL,
     PutObjectRequest,
 } from 'aws-sdk/clients/s3'
 import type { Context } from 'semantic-release'
@@ -94,12 +95,16 @@ export class AWS {
         )
     }
 
-    public async uploadFile(bucket: string, key: string, body: ReadStream, objectMimeType: string) {
+    public async uploadFile(bucket: string, key: string, body: ReadStream, objectMimeType: string, objectACL?: ObjectCannedACL) {
         const uploadParams: PutObjectRequest = {
             Body: body,
             Bucket: bucket,
             ContentType: objectMimeType,
             Key: key,
+        }
+
+        if (objectACL) {
+            uploadParams.ACL = objectACL
         }
 
         return new Promise((resolve, reject) => {

--- a/src/aws.ts
+++ b/src/aws.ts
@@ -97,14 +97,11 @@ export class AWS {
 
     public async uploadFile(bucket: string, key: string, body: ReadStream, objectMimeType: string, objectACL?: ObjectCannedACL) {
         const uploadParams: PutObjectRequest = {
+            ACL: objectACL,
             Body: body,
             Bucket: bucket,
             ContentType: objectMimeType,
             Key: key,
-        }
-
-        if (objectACL) {
-            uploadParams.ACL = objectACL
         }
 
         return new Promise((resolve, reject) => {

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -80,7 +80,8 @@ export async function publish(config: PluginConfig, context: Context) {
             bucketName,
             path.join(bucketPrefix, removedRootFilesPaths[index] ?? filePath),
             fs.createReadStream(filePath),
-            mimeType
+            mimeType,
+            config.objectACL
         )
     }),
     )

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+import type { ObjectCannedACL } from 'aws-sdk/clients/s3'
 import type { Config } from 'semantic-release'
 
 export interface PluginConfig extends Config {
@@ -19,6 +20,12 @@ export interface PluginConfig extends Config {
      * @default ""
      */
     readonly directoryPath: string
+    /**
+     * Object ACL
+     *
+     * @default ""
+     */
+    readonly objectACL?: ObjectCannedACL
     /**
      * if true, all files which are on remote but not staged for upload will be deleted
      *

--- a/yarn.lock
+++ b/yarn.lock
@@ -1280,6 +1280,7 @@ __metadata:
     "@semantic-release/github": ^8.0.7
     "@semantic-release/npm": ^9.0.2
     "@semantic-release/release-notes-generator": ^10.0.3
+    "@types/lodash.template": ^4.5.1
     "@types/mime-types": ^2.1.1
     "@types/semantic-release": ^20.0.1
     aggregate-error: ^3.1.0
@@ -1290,6 +1291,7 @@ __metadata:
     eslint: ^8.35.0
     globby: ^11.1.0
     husky: ^8.0.3
+    lodash.template: ^4.5.0
     mime-types: ^2.1.35
     npm-package-json-lint: ^6.4.0
     pinst: ^3.0.0
@@ -1578,6 +1580,22 @@ __metadata:
   version: 0.0.29
   resolution: "@types/json5@npm:0.0.29"
   checksum: e60b153664572116dfea673c5bda7778dbff150498f44f998e34b5886d8afc47f16799280e4b6e241c0472aef1bc36add771c569c68fc5125fc2ae519a3eb9ac
+  languageName: node
+  linkType: hard
+
+"@types/lodash.template@npm:^4.5.1":
+  version: 4.5.1
+  resolution: "@types/lodash.template@npm:4.5.1"
+  dependencies:
+    "@types/lodash": "*"
+  checksum: b2f5726946ca23c366b39608cc6f4ee90cfefc27a2c8b10856f02dc9748b27a565196b8958ad30de90a7ffa4cb449db24cf7e474dc6322cccfce1fabe996cb0f
+  languageName: node
+  linkType: hard
+
+"@types/lodash@npm:*":
+  version: 4.14.191
+  resolution: "@types/lodash@npm:4.14.191"
+  checksum: ba0d5434e10690869f32d5ea49095250157cae502f10d57de0a723fd72229ce6c6a4979576f0f13e0aa9fbe3ce2457bfb9fa7d4ec3d6daba56730a51906d1491
   languageName: node
   linkType: hard
 
@@ -5973,6 +5991,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lodash._reinterpolate@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "lodash._reinterpolate@npm:3.0.0"
+  checksum: 06d2d5f33169604fa5e9f27b6067ed9fb85d51a84202a656901e5ffb63b426781a601508466f039c720af111b0c685d12f1a5c14ff8df5d5f27e491e562784b2
+  languageName: node
+  linkType: hard
+
 "lodash.camelcase@npm:^4.3.0":
   version: 4.3.0
   resolution: "lodash.camelcase@npm:4.3.0"
@@ -6061,6 +6086,25 @@ __metadata:
   version: 4.4.0
   resolution: "lodash.startcase@npm:4.4.0"
   checksum: c03a4a784aca653845fe09d0ef67c902b6e49288dc45f542a4ab345a9c406a6dc194c774423fa313ee7b06283950301c1221dd2a1d8ecb2dac8dfbb9ed5606b5
+  languageName: node
+  linkType: hard
+
+"lodash.template@npm:^4.5.0":
+  version: 4.5.0
+  resolution: "lodash.template@npm:4.5.0"
+  dependencies:
+    lodash._reinterpolate: ^3.0.0
+    lodash.templatesettings: ^4.0.0
+  checksum: ca64e5f07b6646c9d3dbc0fe3aaa995cb227c4918abd1cef7a9024cd9c924f2fa389a0ec4296aa6634667e029bc81d4bbdb8efbfde11df76d66085e6c529b450
+  languageName: node
+  linkType: hard
+
+"lodash.templatesettings@npm:^4.0.0":
+  version: 4.2.0
+  resolution: "lodash.templatesettings@npm:4.2.0"
+  dependencies:
+    lodash._reinterpolate: ^3.0.0
+  checksum: 863e025478b092997e11a04e9d9e735875eeff1ffcd6c61742aa8272e3c2cddc89ce795eb9726c4e74cef5991f722897ff37df7738a125895f23fc7d12a7bb59
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
First commit:
- Add possibility to set the s3 object ACL on upload

Second commit: 
- Closes #16  

This is the same behavior as the semantic release plugins
![image](https://user-images.githubusercontent.com/16322590/222482425-76aa09fb-3c72-42e7-8a23-2899348e74aa.png)
