### PR TITLE
fix(aws): handle file content-type correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "dependencies": {
         "aggregate-error": "^3.1.0",
         "aws-sdk": "^2.1325.0",
-        "globby": "^11.1.0"
+        "globby": "^11.1.0",
+        "mime-types": "^2.1.35"
     },
     "devDependencies": {
         "@commitlint/cli": "^17.4.4",
@@ -59,6 +60,7 @@
         "@semantic-release/github": "^8.0.7",
         "@semantic-release/npm": "^9.0.2",
         "@semantic-release/release-notes-generator": "^10.0.3",
+        "@types/mime-types": "^2.1.1",
         "@types/semantic-release": "^20.0.1",
         "commitizen": "^4.3.0",
         "conventional-changelog-conventionalcommits": "^5.0.0",

--- a/src/aws.ts
+++ b/src/aws.ts
@@ -9,6 +9,7 @@ import {
 import type {
     ListObjectsV2Request,
     ManagedUpload,
+    PutObjectRequest,
 } from 'aws-sdk/clients/s3'
 import type { Context } from 'semantic-release'
 
@@ -93,10 +94,11 @@ export class AWS {
         )
     }
 
-    public async uploadFile(bucket: string, key: string, body: ReadStream) {
-        const uploadParams = {
+    public async uploadFile(bucket: string, key: string, body: ReadStream, objectMimeType: string) {
+        const uploadParams: PutObjectRequest = {
             Body: body,
             Bucket: bucket,
+            ContentType: objectMimeType,
             Key: key,
         }
 

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -2,6 +2,7 @@ import fs from 'fs'
 import * as path from 'path'
 
 import globby from 'globby'
+import mime from 'mime-types'
 import type { Context } from 'semantic-release'
 
 import { AWS } from './aws'
@@ -71,10 +72,15 @@ export async function publish(config: PluginConfig, context: Context) {
     }
 
     publishPromises.push(...filePaths.map(async (filePath, index) => {
+        const fileName = path.basename(filePath)
+        // 'application/octet-stream' is the default s3 content type for object uploads
+        const mimeType = mime.lookup(fileName) || 'application/octet-stream'
+
         return s3.uploadFile(
             bucketName,
             path.join(bucketPrefix, removedRootFilesPaths[index] ?? filePath),
             fs.createReadStream(filePath),
+            mimeType
         )
     }),
     )

--- a/yarn.lock
+++ b/yarn.lock
@@ -1280,6 +1280,7 @@ __metadata:
     "@semantic-release/github": ^8.0.7
     "@semantic-release/npm": ^9.0.2
     "@semantic-release/release-notes-generator": ^10.0.3
+    "@types/mime-types": ^2.1.1
     "@types/semantic-release": ^20.0.1
     aggregate-error: ^3.1.0
     aws-sdk: ^2.1325.0
@@ -1289,6 +1290,7 @@ __metadata:
     eslint: ^8.35.0
     globby: ^11.1.0
     husky: ^8.0.3
+    mime-types: ^2.1.35
     npm-package-json-lint: ^6.4.0
     pinst: ^3.0.0
     prettier: ^2.8.4
@@ -1576,6 +1578,13 @@ __metadata:
   version: 0.0.29
   resolution: "@types/json5@npm:0.0.29"
   checksum: e60b153664572116dfea673c5bda7778dbff150498f44f998e34b5886d8afc47f16799280e4b6e241c0472aef1bc36add771c569c68fc5125fc2ae519a3eb9ac
+  languageName: node
+  linkType: hard
+
+"@types/mime-types@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "@types/mime-types@npm:2.1.1"
+  checksum: 106b5d556add46446a579ad25ff15d6b421851790d887edcad558c90c1e64b1defc72bfbaf4b08f208916e21d9cc45cdb951d77be51268b18221544cfe054a3c
   languageName: node
   linkType: hard
 
@@ -6273,6 +6282,22 @@ __metadata:
     braces: ^3.0.2
     picomatch: ^2.3.1
   checksum: 02a17b671c06e8fefeeb6ef996119c1e597c942e632a21ef589154f23898c9c6a9858526246abb14f8bca6e77734aa9dcf65476fca47cedfb80d9577d52843fc
+  languageName: node
+  linkType: hard
+
+"mime-db@npm:1.52.0":
+  version: 1.52.0
+  resolution: "mime-db@npm:1.52.0"
+  checksum: 0d99a03585f8b39d68182803b12ac601d9c01abfa28ec56204fa330bc9f3d1c5e14beb049bafadb3dbdf646dfb94b87e24d4ec7b31b7279ef906a8ea9b6a513f
+  languageName: node
+  linkType: hard
+
+"mime-types@npm:^2.1.35":
+  version: 2.1.35
+  resolution: "mime-types@npm:2.1.35"
+  dependencies:
+    mime-db: 1.52.0
+  checksum: 89a5b7f1def9f3af5dad6496c5ed50191ae4331cc5389d7c521c8ad28d5fdad2d06fd81baf38fed813dc4e46bb55c8145bb0ff406330818c9cf712fb2e9b3836
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Every file upload on S3 has `content-type: 'application/octet-stream'`, the goal is to determine the mime-type of uploaded file and set the good content-type.