### PR TITLE
feat(publish): return release context to be able to use it in other plugins

### DIFF
--- a/src/publish.ts
+++ b/src/publish.ts
@@ -96,4 +96,9 @@ export async function publish(config: PluginConfig, context: Context) {
     )
 
     await Promise.allSettled(publishPromises)
+
+    return {
+        name: 'S3 release',
+        url: `https://${bucketName}.s3.amazonaws.com/${bucketPrefix}`,
+    }
 }


### PR DESCRIPTION
The goal is to return the release context in publish method, to be able to use it in other plugins, for example : 

https://github.com/semantic-release/github#addreleases

And include release link in release message : 

https://github.com/semantic-release/github/pull/282